### PR TITLE
Fix Azure workbook to only pull 20 employees from server

### DIFF
--- a/ios/AzureAppService/Azure App Service.workbook
+++ b/ios/AzureAppService/Azure App Service.workbook
@@ -11,6 +11,7 @@
 We’ve started by adding the `Microsoft.Azure.Mobile.Client` and `Microsoft.ProjectOxford.Emotion` NuGets to the iOS Workbook. The references are loaded into the workbook.
 
 ```csharp
+#r "System.Collections"
 #r "System.IO"
 #r "System.Runtime"
 #r "System.Threading.Tasks"
@@ -46,7 +47,6 @@ public class Employee
 With Azure Easy Tables, reading data is a snap:
 
 ```csharp
-#r "System.Collections"
 using Microsoft.WindowsAzure.MobileServices;
 
 var mobileService = new MobileServiceClient ("http://evolvedemo.azurewebsites.net");

--- a/ios/AzureAppService/Azure App Service.workbook
+++ b/ios/AzureAppService/Azure App Service.workbook
@@ -46,6 +46,7 @@ public class Employee
 With Azure Easy Tables, reading data is a snap:
 
 ```csharp
+#r "System.Collections"
 using Microsoft.WindowsAzure.MobileServices;
 
 var mobileService = new MobileServiceClient ("http://evolvedemo.azurewebsites.net");
@@ -53,7 +54,7 @@ var table = mobileService.GetTable<Employee> ();
 
 static List<Employee> employees;
 
-employees = (await table.ReadAsync ()).Take (20).ToList ();
+employees = await table.Take (20).ToListAsync ();
 ```
 
 Here we fetch the avatar images for each employee and cache them back on the model object. Inspecting the `employees` list now shows happy faces!


### PR DESCRIPTION
The original implementation was querying the server for all employees and then filtering locally. 